### PR TITLE
Version 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ install(EXPORT throttr-protocolTargets
 
 write_basic_package_version_file(
         "${CMAKE_CURRENT_BINARY_DIR}/throttr-protocolConfigVersion.cmake"
-        VERSION 2.0.1
+        VERSION 4.0.0
         COMPATIBILITY SameMajorVersion
 )
 

--- a/include/throttr/protocol.hpp
+++ b/include/throttr/protocol.hpp
@@ -64,32 +64,32 @@ namespace throttr {
         /**
          * Nanoseconds
          */
-        nanoseconds = 0x00,
+        nanoseconds = 0x01,
 
         /**
          * Microseconds
          */
-        microseconds = 0x01,
+        microseconds = 0x02,
 
         /**
          * Milliseconds
          */
-        milliseconds = 0x02,
+        milliseconds = 0x03,
 
         /**
          * Seconds
          */
-        seconds = 0x03,
+        seconds = 0x04,
 
         /**
          * Minutes
          */
-        minutes = 0x04,
+        minutes = 0x05,
 
         /**
          * Hours
          */
-        hours = 0x05,
+        hours = 0x06,
     };
 
     /**
@@ -137,27 +137,27 @@ namespace throttr {
         /**
          * Request type
          */
-        request_types request_type_; // 1 byte
+        request_types request_type_;
 
         /**
          * Quota
          */
-        uint16_t quota_; // 8 bytes
+        uint16_t quota_;
 
         /**
          * TTL type
          */
-        ttl_types ttl_type_; // 1 byte
+        ttl_types ttl_type_;
 
         /**
          * TTL
          */
-        uint16_t ttl_; // 8 bytes
+        uint16_t ttl_;
 
         /**
-         * Key ID size
+         * Key size
          */
-        uint8_t key_size_; // 1 byte
+        uint8_t key_size_;
     };
 #pragma pack(pop)
 
@@ -175,12 +175,12 @@ namespace throttr {
         /**
          * Request type
          */
-        request_types request_type_; // 1 byte
+        request_types request_type_;
 
         /**
-         * Key ID size
+         * Key size
          */
-        uint8_t key_size_; // 1 byte
+        uint8_t key_size_;
     };
 #pragma pack(pop)
 
@@ -216,9 +216,9 @@ namespace throttr {
         uint16_t value_;
 
         /**
-         * Key ID size
+         * Key size
          */
-        uint8_t key_size_; // 1 byte
+        uint8_t key_size_;
     };
 #pragma pack(pop)
 
@@ -240,9 +240,9 @@ namespace throttr {
         request_types request_type_;
 
         /**
-         * Key ID size
+         * Key size
          */
-        uint8_t key_size_; // 1 byte
+        uint8_t key_size_;
     };
 #pragma pack(pop)
 
@@ -317,7 +317,7 @@ namespace throttr {
         const request_query_header *header_ = nullptr;
 
         /**
-         * Key ID
+         * Key
          */
         std::string_view key_;
 
@@ -373,7 +373,7 @@ namespace throttr {
         const request_update_header *header_ = nullptr;
 
         /**
-         * Key ID
+         * Key
          */
         std::string_view key_;
 
@@ -430,7 +430,7 @@ namespace throttr {
         const request_purge_header *header_ = nullptr;
 
         /**
-         * Key ID
+         * Key
          */
         std::string_view key_;
 
@@ -482,7 +482,7 @@ namespace throttr {
      */
     struct request_key {
         /**
-         * Key ID
+         * Key
          */
         std::string_view key_;
 

--- a/include/throttr/protocol.hpp
+++ b/include/throttr/protocol.hpp
@@ -566,7 +566,9 @@ namespace throttr {
          * @param other
          * @return bool
          */
-        bool operator==(const request_key &other) const = default;
+        bool operator==(const request_key &other) const {
+            return consumer_id_ == other.consumer_id_ && resource_id_ == other.resource_id_;
+        };
     };
 
     /**

--- a/include/throttr/protocol.hpp
+++ b/include/throttr/protocol.hpp
@@ -67,14 +67,29 @@ namespace throttr {
         nanoseconds = 0x00,
 
         /**
+         * Microseconds
+         */
+        microseconds = 0x01,
+
+        /**
          * Milliseconds
          */
-        milliseconds = 0x01,
+        milliseconds = 0x02,
 
         /**
          * Seconds
          */
-        seconds = 0x02,
+        seconds = 0x03,
+
+        /**
+         * Minutes
+         */
+        minutes = 0x04,
+
+        /**
+         * Hours
+         */
+        hours = 0x05,
     };
 
     /**
@@ -125,14 +140,9 @@ namespace throttr {
         request_types request_type_; // 1 byte
 
         /**
-         * Request ID
-         */
-        uint32_t request_id_; // 4 bytes
-
-        /**
          * Quota
          */
-        uint64_t quota_; // 8 bytes
+        uint16_t quota_; // 8 bytes
 
         /**
          * TTL type
@@ -142,17 +152,12 @@ namespace throttr {
         /**
          * TTL
          */
-        uint64_t ttl_; // 8 bytes
+        uint16_t ttl_; // 8 bytes
 
         /**
-         * Consumer ID size
+         * Key ID size
          */
-        uint8_t consumer_id_size_; // 1 byte
-
-        /**
-         * Resource ID size
-         */
-        uint8_t resource_id_size_; // 1 byte
+        uint8_t key_id_size_; // 1 byte
     };
 #pragma pack(pop)
 
@@ -173,19 +178,9 @@ namespace throttr {
         request_types request_type_; // 1 byte
 
         /**
-         * Request ID
+         * Key ID size
          */
-        uint32_t request_id_; // 4 bytes
-
-        /**
-         * Consumer ID size
-         */
-        uint8_t consumer_id_size_; // 1 byte
-
-        /**
-         * Resource ID size
-         */
-        uint8_t resource_id_size_; // 1 byte
+        uint8_t key_id_size_; // 1 byte
     };
 #pragma pack(pop)
 
@@ -206,11 +201,6 @@ namespace throttr {
         request_types request_type_;
 
         /**
-         * Request ID
-         */
-        uint32_t request_id_;
-
-        /**
          * Attribute
          */
         attribute_types attribute_;
@@ -223,17 +213,12 @@ namespace throttr {
         /**
          * Value
          */
-        uint64_t value_;
+        uint16_t value_;
 
         /**
-         * Consumer ID size
+         * Key ID size
          */
-        uint8_t consumer_id_size_;
-
-        /**
-         * Resource ID size
-         */
-        uint8_t resource_id_size_;
+        uint8_t key_id_size_; // 1 byte
     };
 #pragma pack(pop)
 
@@ -255,19 +240,9 @@ namespace throttr {
         request_types request_type_;
 
         /**
-         * Request ID
+         * Key ID size
          */
-        uint32_t request_id_;
-
-        /**
-         * Consumer ID size
-         */
-        uint8_t consumer_id_size_;
-
-        /**
-         * Resource ID size
-         */
-        uint8_t resource_id_size_;
+        uint8_t key_id_size_; // 1 byte
     };
 #pragma pack(pop)
 
@@ -286,14 +261,9 @@ namespace throttr {
         const request_insert_header *header_ = nullptr;
 
         /**
-         * Consumer ID
+         * Key ID
          */
-        std::string_view consumer_id_;
-
-        /**
-         * Resource ID
-         */
-        std::string_view resource_id_;
+        std::string_view key_id_;
 
         /**
          * From buffer
@@ -308,19 +278,15 @@ namespace throttr {
 
             const auto *_header = reinterpret_cast<const request_insert_header *>(buffer.data()); // NOSONAR
 
-            if (const auto _expected = static_cast<std::size_t>(_header->consumer_id_size_) + _header->resource_id_size_
-                ; buffer.size() < request_insert_header_size + _expected) {
+            if (buffer.size() < request_insert_header_size + _header->key_id_size_) {
                 throw request_error("buffer too small for request_insert payload");
             }
 
-            const auto _consumer_id = buffer.subspan(request_insert_header_size, _header->consumer_id_size_);
-            const auto _resource_id = buffer.subspan(request_insert_header_size + _header->consumer_id_size_,
-                                                     _header->resource_id_size_);
+            const auto _key_id = buffer.subspan(request_insert_header_size, _header->key_id_size_);
 
             return request_insert{
                 _header,
-                std::string_view(reinterpret_cast<const char *>(_consumer_id.data()), _consumer_id.size()), // NOSONAR
-                std::string_view(reinterpret_cast<const char *>(_resource_id.data()), _resource_id.size()) // NOSONAR
+                std::string_view(reinterpret_cast<const char *>(_key_id.data()), _key_id.size()), // NOSONAR
             };
         }
 
@@ -332,12 +298,10 @@ namespace throttr {
         [[nodiscard]]
         std::vector<std::byte> to_buffer() const {
             std::vector<std::byte> _buffer;
-            _buffer.resize(request_insert_header_size + consumer_id_.size() + resource_id_.size());
+            _buffer.resize(request_insert_header_size + key_id_.size());
 
             std::memcpy(_buffer.data(), header_, request_insert_header_size);
-            std::memcpy(_buffer.data() + request_insert_header_size, consumer_id_.data(), consumer_id_.size());
-            std::memcpy(_buffer.data() + request_insert_header_size + consumer_id_.size(), resource_id_.data(),
-                        resource_id_.size());
+            std::memcpy(_buffer.data() + request_insert_header_size, key_id_.data(), key_id_.size());
 
             return _buffer;
         }
@@ -353,14 +317,9 @@ namespace throttr {
         const request_query_header *header_ = nullptr;
 
         /**
-         * Consumer ID
+         * Key ID
          */
-        std::string_view consumer_id_;
-
-        /**
-         * Resource ID
-         */
-        std::string_view resource_id_;
+        std::string_view key_id_;
 
         /**
          * From buffer
@@ -375,19 +334,15 @@ namespace throttr {
 
             const auto *_header = reinterpret_cast<const request_query_header *>(buffer.data()); // NOSONAR
 
-            if (const auto _expected = _header->consumer_id_size_ + _header->resource_id_size_
-                ; buffer.size() < request_query_header_size + _expected) {
+            if (buffer.size() < request_query_header_size + _header->key_id_size_) {
                 throw request_error("buffer too small for request_query payload");
             }
 
-            const auto _consumer_id = buffer.subspan(request_query_header_size, _header->consumer_id_size_);
-            const auto _resource_id = buffer.subspan(request_query_header_size + _header->consumer_id_size_,
-                                                     _header->resource_id_size_);
+            const auto _key_id = buffer.subspan(request_query_header_size, _header->key_id_size_);
 
             return request_query{
                 _header,
-                std::string_view(reinterpret_cast<const char *>(_consumer_id.data()), _consumer_id.size()), // NOSONAR
-                std::string_view(reinterpret_cast<const char *>(_resource_id.data()), _resource_id.size()) // NOSONAR
+                std::string_view(reinterpret_cast<const char *>(_key_id.data()), _key_id.size()), // NOSONAR
             };
         }
 
@@ -399,12 +354,10 @@ namespace throttr {
         [[nodiscard]]
         std::vector<std::byte> to_buffer() const {
             std::vector<std::byte> _buffer;
-            _buffer.resize(request_query_header_size + consumer_id_.size() + resource_id_.size());
+            _buffer.resize(request_query_header_size + key_id_.size());
 
             std::memcpy(_buffer.data(), header_, request_query_header_size);
-            std::memcpy(_buffer.data() + request_query_header_size, consumer_id_.data(), consumer_id_.size());
-            std::memcpy(_buffer.data() + request_query_header_size + consumer_id_.size(), resource_id_.data(),
-                        resource_id_.size());
+            std::memcpy(_buffer.data() + request_query_header_size, key_id_.data(), key_id_.size());
 
             return _buffer;
         }
@@ -420,14 +373,9 @@ namespace throttr {
         const request_update_header *header_ = nullptr;
 
         /**
-         * Consumer ID
+         * Key ID
          */
-        std::string_view consumer_id_;
-
-        /**
-         * Resource ID
-         */
-        std::string_view resource_id_;
+        std::string_view key_id_;
 
         /**
          * From buffer
@@ -442,19 +390,15 @@ namespace throttr {
 
             const auto *_header = reinterpret_cast<const request_update_header *>(buffer.data()); // NOSONAR
 
-            if (const auto _expected = static_cast<std::size_t>(_header->consumer_id_size_) + _header->resource_id_size_
-                ; buffer.size() < request_update_header_size + _expected) {
+            if (buffer.size() < request_update_header_size + _header->key_id_size_) {
                 throw request_error("buffer too small for request_update payload");
             }
 
-            const auto _consumer_id = buffer.subspan(request_update_header_size, _header->consumer_id_size_);
-            const auto _resource_id = buffer.subspan(request_update_header_size + _header->consumer_id_size_,
-                                                     _header->resource_id_size_);
+            const auto _key_id = buffer.subspan(request_update_header_size, _header->key_id_size_);
 
             return request_update{
                 _header,
-                std::string_view(reinterpret_cast<const char *>(_consumer_id.data()), _consumer_id.size()), // NOSONAR
-                std::string_view(reinterpret_cast<const char *>(_resource_id.data()), _resource_id.size()) // NOSONAR
+                std::string_view(reinterpret_cast<const char *>(_key_id.data()), _key_id.size()), // NOSONAR
             };
         }
 
@@ -466,12 +410,10 @@ namespace throttr {
         [[nodiscard]]
         std::vector<std::byte> to_buffer() const {
             std::vector<std::byte> _buffer;
-            _buffer.resize(request_update_header_size + consumer_id_.size() + resource_id_.size());
+            _buffer.resize(request_update_header_size + key_id_.size());
 
             std::memcpy(_buffer.data(), header_, request_update_header_size);
-            std::memcpy(_buffer.data() + request_update_header_size, consumer_id_.data(), consumer_id_.size());
-            std::memcpy(_buffer.data() + request_update_header_size + consumer_id_.size(), resource_id_.data(),
-                        resource_id_.size());
+            std::memcpy(_buffer.data() + request_update_header_size, key_id_.data(), key_id_.size());
 
             return _buffer;
         }
@@ -488,14 +430,9 @@ namespace throttr {
         const request_purge_header *header_ = nullptr;
 
         /**
-         * Consumer ID
+         * Key ID
          */
-        std::string_view consumer_id_;
-
-        /**
-         * Resource ID
-         */
-        std::string_view resource_id_;
+        std::string_view key_id_;
 
         /**
          * From buffer
@@ -510,19 +447,15 @@ namespace throttr {
 
             const auto *_header = reinterpret_cast<const request_purge_header *>(buffer.data()); // NOSONAR
 
-            if (const auto _expected = _header->consumer_id_size_ + _header->resource_id_size_
-                ; buffer.size() < request_purge_header_size + _expected) {
+            if (buffer.size() < request_purge_header_size + _header->key_id_size_) {
                 throw request_error("buffer too small for request_purge payload");
             }
 
-            const auto _consumer_id = buffer.subspan(request_purge_header_size, _header->consumer_id_size_);
-            const auto _resource_id = buffer.subspan(request_purge_header_size + _header->consumer_id_size_,
-                                                     _header->resource_id_size_);
+            const auto _key_id = buffer.subspan(request_purge_header_size, _header->key_id_size_);
 
             return request_purge{
                 _header,
-                std::string_view(reinterpret_cast<const char *>(_consumer_id.data()), _consumer_id.size()), // NOSONAR
-                std::string_view(reinterpret_cast<const char *>(_resource_id.data()), _resource_id.size()) // NOSONAR
+                std::string_view(reinterpret_cast<const char *>(_key_id.data()), _key_id.size()), // NOSONAR
             };
         }
 
@@ -534,12 +467,10 @@ namespace throttr {
         [[nodiscard]]
         std::vector<std::byte> to_buffer() const {
             std::vector<std::byte> _buffer;
-            _buffer.resize(request_purge_header_size + consumer_id_.size() + resource_id_.size());
+            _buffer.resize(request_purge_header_size + key_id_.size());
 
             std::memcpy(_buffer.data(), header_, request_purge_header_size);
-            std::memcpy(_buffer.data() + request_purge_header_size, consumer_id_.data(), consumer_id_.size());
-            std::memcpy(_buffer.data() + request_purge_header_size + consumer_id_.size(), resource_id_.data(),
-                        resource_id_.size());
+            std::memcpy(_buffer.data() + request_purge_header_size, key_id_.data(), key_id_.size());
 
             return _buffer;
         }
@@ -551,14 +482,9 @@ namespace throttr {
      */
     struct request_key {
         /**
-         * Consumer ID
+         * Key ID
          */
-        std::string_view consumer_id_;
-
-        /**
-         * Resource ID
-         */
-        std::string_view resource_id_;
+        std::string_view key_id_;
 
         /**
          * Comparator
@@ -566,9 +492,7 @@ namespace throttr {
          * @param other
          * @return bool
          */
-        bool operator==(const request_key &other) const {
-            return consumer_id_ == other.consumer_id_ && resource_id_ == other.resource_id_;
-        };
+        bool operator==(const request_key &other) const = default;
     };
 
     /**
@@ -582,9 +506,7 @@ namespace throttr {
          * @return std::size_t
          */
         std::size_t operator()(const request_key &key) const {
-            std::size_t _h = std::hash<std::string_view>{}(key.consumer_id_);
-            _h ^= std::hash<std::string_view>{}(key.resource_id_) + 0x9e3779b9 + (_h << 6) + (_h >> 2);
-            return _h;
+            return std::hash<std::string_view>{}(key.key_id_);
         }
     };
 
@@ -595,7 +517,7 @@ namespace throttr {
         /**
          * Quota
          */
-        uint64_t quota_ = 0;
+        uint16_t quota_ = 0;
 
         /**
          * TTL type
@@ -611,37 +533,29 @@ namespace throttr {
     /**
      * Request insert builder
      *
-     * @param id
      * @param quota
      * @param ttl_type
      * @param ttl
-     * @param consumer_id
-     * @param resource_id
+     * @param key_id
      * @return std::vector<std::byte>
      */
     inline std::vector<std::byte> request_insert_builder(
-        const uint32_t id = 0,
-        const uint64_t quota = 0,
+        const uint16_t quota = 0,
         const ttl_types ttl_type = ttl_types::milliseconds,
-        const uint64_t ttl = 0,
-        const std::string_view consumer_id = "",
-        const std::string_view resource_id = ""
+        const uint16_t ttl = 0,
+        const std::string_view key_id = ""
     ) {
         std::vector<std::byte> _buffer;
-        _buffer.resize(request_insert_header_size + consumer_id.size() + resource_id.size());
+        _buffer.resize(request_insert_header_size + key_id.size());
 
         auto *_header = reinterpret_cast<request_insert_header *>(_buffer.data()); // NOSONAR
         _header->request_type_ = request_types::insert;
-        _header->request_id_ = id;
         _header->quota_ = quota;
         _header->ttl_type_ = ttl_type;
         _header->ttl_ = ttl;
-        _header->consumer_id_size_ = static_cast<uint8_t>(consumer_id.size());
-        _header->resource_id_size_ = static_cast<uint8_t>(resource_id.size());
+        _header->key_id_size_ = static_cast<uint8_t>(key_id.size());
 
-        std::memcpy(_buffer.data() + request_insert_header_size, consumer_id.data(), consumer_id.size());
-        std::memcpy(_buffer.data() + request_insert_header_size + consumer_id.size(), resource_id.data(),
-                    resource_id.size());
+        std::memcpy(_buffer.data() + request_insert_header_size, key_id.data(), key_id.size());
 
         return _buffer;
     }
@@ -649,28 +563,19 @@ namespace throttr {
     /**
      * Request query builder
      *
-     * @param id
-     * @param consumer_id
-     * @param resource_id
+     * @param key_id
      * @return std::vector<std::byte>
      */
     inline std::vector<std::byte> request_query_builder(
-        const uint32_t id = 0,
-        const std::string_view consumer_id = "",
-        const std::string_view resource_id = ""
+        const std::string_view key_id = ""
     ) {
         std::vector<std::byte> _buffer;
-        _buffer.resize(request_query_header_size + consumer_id.size() + resource_id.size());
+        _buffer.resize(request_query_header_size + key_id.size());
 
         auto *_header = reinterpret_cast<request_query_header *>(_buffer.data()); // NOSONAR
         _header->request_type_ = request_types::query;
-        _header->request_id_ = id;
-        _header->consumer_id_size_ = static_cast<uint8_t>(consumer_id.size());
-        _header->resource_id_size_ = static_cast<uint8_t>(resource_id.size());
 
-        std::memcpy(_buffer.data() + request_query_header_size, consumer_id.data(), consumer_id.size());
-        std::memcpy(_buffer.data() + request_query_header_size + consumer_id.size(), resource_id.data(),
-                    resource_id.size());
+        std::memcpy(_buffer.data() + request_query_header_size, key_id.data(), key_id.size());
 
         return _buffer;
     }
@@ -679,28 +584,20 @@ namespace throttr {
     /**
      * Request purge builder
      *
-     * @param id
-     * @param consumer_id
-     * @param resource_id
+     * @param key_id
      * @return std::vector<std::byte>
      */
     inline std::vector<std::byte> request_purge_builder(
-        const uint32_t id = 0,
-        const std::string_view consumer_id = "",
-        const std::string_view resource_id = ""
+        const std::string_view key_id = ""
     ) {
         std::vector<std::byte> _buffer;
-        _buffer.resize(request_purge_header_size + consumer_id.size() + resource_id.size());
+        _buffer.resize(request_purge_header_size + key_id.size());
 
         auto *_header = reinterpret_cast<request_purge_header *>(_buffer.data()); // NOSONAR
         _header->request_type_ = request_types::purge;
-        _header->request_id_ = id;
-        _header->consumer_id_size_ = static_cast<uint8_t>(consumer_id.size());
-        _header->resource_id_size_ = static_cast<uint8_t>(resource_id.size());
+        _header->key_id_size_ = static_cast<uint8_t>(key_id.size());
 
-        std::memcpy(_buffer.data() + request_purge_header_size, consumer_id.data(), consumer_id.size());
-        std::memcpy(_buffer.data() + request_purge_header_size + consumer_id.size(), resource_id.data(),
-                    resource_id.size());
+        std::memcpy(_buffer.data() + request_purge_header_size, key_id.data(), key_id.size());
 
         return _buffer;
     }
@@ -708,37 +605,29 @@ namespace throttr {
     /**
      * Request update builder
      *
-     * @param id
      * @param attribute
      * @param change
      * @param value
-     * @param consumer_id
-     * @param resource_id
+     * @param key_id
      * @return std::vector<std::byte>
      */
     inline std::vector<std::byte> request_update_builder(
-        const uint32_t id = 0,
         const attribute_types attribute = attribute_types::quota,
         const change_types change = change_types::patch,
-        const uint64_t value = 0,
-        const std::string_view consumer_id = "",
-        const std::string_view resource_id = ""
+        const uint16_t value = 0,
+        const std::string_view key_id = ""
     ) {
         std::vector<std::byte> _buffer;
-        _buffer.resize(request_update_header_size + consumer_id.size() + resource_id.size());
+        _buffer.resize(request_update_header_size + key_id.size());
 
         auto *_header = reinterpret_cast<request_update_header *>(_buffer.data()); // NOSONAR
         _header->request_type_ = request_types::update;
-        _header->request_id_ = id;
         _header->attribute_ = attribute;
         _header->change_ = change;
         _header->value_ = value;
-        _header->consumer_id_size_ = static_cast<uint8_t>(consumer_id.size());
-        _header->resource_id_size_ = static_cast<uint8_t>(resource_id.size());
+        _header->key_id_size_ = static_cast<uint8_t>(key_id.size());
 
-        std::memcpy(_buffer.data() + request_update_header_size, consumer_id.data(), consumer_id.size());
-        std::memcpy(_buffer.data() + request_update_header_size + consumer_id.size(), resource_id.data(),
-                    resource_id.size());
+        std::memcpy(_buffer.data() + request_update_header_size, key_id.data(), key_id.size());
 
         return _buffer;
     }

--- a/include/throttr/protocol.hpp
+++ b/include/throttr/protocol.hpp
@@ -157,7 +157,7 @@ namespace throttr {
         /**
          * Key ID size
          */
-        uint8_t key_id_size_; // 1 byte
+        uint8_t key_size_; // 1 byte
     };
 #pragma pack(pop)
 
@@ -180,7 +180,7 @@ namespace throttr {
         /**
          * Key ID size
          */
-        uint8_t key_id_size_; // 1 byte
+        uint8_t key_size_; // 1 byte
     };
 #pragma pack(pop)
 
@@ -218,7 +218,7 @@ namespace throttr {
         /**
          * Key ID size
          */
-        uint8_t key_id_size_; // 1 byte
+        uint8_t key_size_; // 1 byte
     };
 #pragma pack(pop)
 
@@ -242,7 +242,7 @@ namespace throttr {
         /**
          * Key ID size
          */
-        uint8_t key_id_size_; // 1 byte
+        uint8_t key_size_; // 1 byte
     };
 #pragma pack(pop)
 
@@ -263,7 +263,7 @@ namespace throttr {
         /**
          * Key ID
          */
-        std::string_view key_id_;
+        std::string_view key_;
 
         /**
          * From buffer
@@ -278,15 +278,15 @@ namespace throttr {
 
             const auto *_header = reinterpret_cast<const request_insert_header *>(buffer.data()); // NOSONAR
 
-            if (buffer.size() < request_insert_header_size + _header->key_id_size_) {
+            if (buffer.size() < request_insert_header_size + _header->key_size_) {
                 throw request_error("buffer too small for request_insert payload");
             }
 
-            const auto _key_id = buffer.subspan(request_insert_header_size, _header->key_id_size_);
+            const auto _key = buffer.subspan(request_insert_header_size, _header->key_size_);
 
             return request_insert{
                 _header,
-                std::string_view(reinterpret_cast<const char *>(_key_id.data()), _key_id.size()), // NOSONAR
+                std::string_view(reinterpret_cast<const char *>(_key.data()), _key.size()), // NOSONAR
             };
         }
 
@@ -298,10 +298,10 @@ namespace throttr {
         [[nodiscard]]
         std::vector<std::byte> to_buffer() const {
             std::vector<std::byte> _buffer;
-            _buffer.resize(request_insert_header_size + key_id_.size());
+            _buffer.resize(request_insert_header_size + key_.size());
 
             std::memcpy(_buffer.data(), header_, request_insert_header_size);
-            std::memcpy(_buffer.data() + request_insert_header_size, key_id_.data(), key_id_.size());
+            std::memcpy(_buffer.data() + request_insert_header_size, key_.data(), key_.size());
 
             return _buffer;
         }
@@ -319,7 +319,7 @@ namespace throttr {
         /**
          * Key ID
          */
-        std::string_view key_id_;
+        std::string_view key_;
 
         /**
          * From buffer
@@ -334,15 +334,15 @@ namespace throttr {
 
             const auto *_header = reinterpret_cast<const request_query_header *>(buffer.data()); // NOSONAR
 
-            if (buffer.size() < request_query_header_size + _header->key_id_size_) {
+            if (buffer.size() < request_query_header_size + _header->key_size_) {
                 throw request_error("buffer too small for request_query payload");
             }
 
-            const auto _key_id = buffer.subspan(request_query_header_size, _header->key_id_size_);
+            const auto _key = buffer.subspan(request_query_header_size, _header->key_size_);
 
             return request_query{
                 _header,
-                std::string_view(reinterpret_cast<const char *>(_key_id.data()), _key_id.size()), // NOSONAR
+                std::string_view(reinterpret_cast<const char *>(_key.data()), _key.size()), // NOSONAR
             };
         }
 
@@ -354,10 +354,10 @@ namespace throttr {
         [[nodiscard]]
         std::vector<std::byte> to_buffer() const {
             std::vector<std::byte> _buffer;
-            _buffer.resize(request_query_header_size + key_id_.size());
+            _buffer.resize(request_query_header_size + key_.size());
 
             std::memcpy(_buffer.data(), header_, request_query_header_size);
-            std::memcpy(_buffer.data() + request_query_header_size, key_id_.data(), key_id_.size());
+            std::memcpy(_buffer.data() + request_query_header_size, key_.data(), key_.size());
 
             return _buffer;
         }
@@ -375,7 +375,7 @@ namespace throttr {
         /**
          * Key ID
          */
-        std::string_view key_id_;
+        std::string_view key_;
 
         /**
          * From buffer
@@ -390,15 +390,15 @@ namespace throttr {
 
             const auto *_header = reinterpret_cast<const request_update_header *>(buffer.data()); // NOSONAR
 
-            if (buffer.size() < request_update_header_size + _header->key_id_size_) {
+            if (buffer.size() < request_update_header_size + _header->key_size_) {
                 throw request_error("buffer too small for request_update payload");
             }
 
-            const auto _key_id = buffer.subspan(request_update_header_size, _header->key_id_size_);
+            const auto _key = buffer.subspan(request_update_header_size, _header->key_size_);
 
             return request_update{
                 _header,
-                std::string_view(reinterpret_cast<const char *>(_key_id.data()), _key_id.size()), // NOSONAR
+                std::string_view(reinterpret_cast<const char *>(_key.data()), _key.size()), // NOSONAR
             };
         }
 
@@ -410,10 +410,10 @@ namespace throttr {
         [[nodiscard]]
         std::vector<std::byte> to_buffer() const {
             std::vector<std::byte> _buffer;
-            _buffer.resize(request_update_header_size + key_id_.size());
+            _buffer.resize(request_update_header_size + key_.size());
 
             std::memcpy(_buffer.data(), header_, request_update_header_size);
-            std::memcpy(_buffer.data() + request_update_header_size, key_id_.data(), key_id_.size());
+            std::memcpy(_buffer.data() + request_update_header_size, key_.data(), key_.size());
 
             return _buffer;
         }
@@ -432,7 +432,7 @@ namespace throttr {
         /**
          * Key ID
          */
-        std::string_view key_id_;
+        std::string_view key_;
 
         /**
          * From buffer
@@ -447,15 +447,15 @@ namespace throttr {
 
             const auto *_header = reinterpret_cast<const request_purge_header *>(buffer.data()); // NOSONAR
 
-            if (buffer.size() < request_purge_header_size + _header->key_id_size_) {
+            if (buffer.size() < request_purge_header_size + _header->key_size_) {
                 throw request_error("buffer too small for request_purge payload");
             }
 
-            const auto _key_id = buffer.subspan(request_purge_header_size, _header->key_id_size_);
+            const auto _key = buffer.subspan(request_purge_header_size, _header->key_size_);
 
             return request_purge{
                 _header,
-                std::string_view(reinterpret_cast<const char *>(_key_id.data()), _key_id.size()), // NOSONAR
+                std::string_view(reinterpret_cast<const char *>(_key.data()), _key.size()), // NOSONAR
             };
         }
 
@@ -467,10 +467,10 @@ namespace throttr {
         [[nodiscard]]
         std::vector<std::byte> to_buffer() const {
             std::vector<std::byte> _buffer;
-            _buffer.resize(request_purge_header_size + key_id_.size());
+            _buffer.resize(request_purge_header_size + key_.size());
 
             std::memcpy(_buffer.data(), header_, request_purge_header_size);
-            std::memcpy(_buffer.data() + request_purge_header_size, key_id_.data(), key_id_.size());
+            std::memcpy(_buffer.data() + request_purge_header_size, key_.data(), key_.size());
 
             return _buffer;
         }
@@ -484,7 +484,7 @@ namespace throttr {
         /**
          * Key ID
          */
-        std::string_view key_id_;
+        std::string_view key_;
 
         /**
          * Comparator
@@ -506,7 +506,7 @@ namespace throttr {
          * @return std::size_t
          */
         std::size_t operator()(const request_key &key) const {
-            return std::hash<std::string_view>{}(key.key_id_);
+            return std::hash<std::string_view>{}(key.key_);
         }
     };
 
@@ -536,26 +536,26 @@ namespace throttr {
      * @param quota
      * @param ttl_type
      * @param ttl
-     * @param key_id
+     * @param key
      * @return std::vector<std::byte>
      */
     inline std::vector<std::byte> request_insert_builder(
         const uint16_t quota = 0,
         const ttl_types ttl_type = ttl_types::milliseconds,
         const uint16_t ttl = 0,
-        const std::string_view key_id = ""
+        const std::string_view key = ""
     ) {
         std::vector<std::byte> _buffer;
-        _buffer.resize(request_insert_header_size + key_id.size());
+        _buffer.resize(request_insert_header_size + key.size());
 
         auto *_header = reinterpret_cast<request_insert_header *>(_buffer.data()); // NOSONAR
         _header->request_type_ = request_types::insert;
         _header->quota_ = quota;
         _header->ttl_type_ = ttl_type;
         _header->ttl_ = ttl;
-        _header->key_id_size_ = static_cast<uint8_t>(key_id.size());
+        _header->key_size_ = static_cast<uint8_t>(key.size());
 
-        std::memcpy(_buffer.data() + request_insert_header_size, key_id.data(), key_id.size());
+        std::memcpy(_buffer.data() + request_insert_header_size, key.data(), key.size());
 
         return _buffer;
     }
@@ -563,19 +563,20 @@ namespace throttr {
     /**
      * Request query builder
      *
-     * @param key_id
+     * @param key
      * @return std::vector<std::byte>
      */
     inline std::vector<std::byte> request_query_builder(
-        const std::string_view key_id = ""
+        const std::string_view key = ""
     ) {
         std::vector<std::byte> _buffer;
-        _buffer.resize(request_query_header_size + key_id.size());
+        _buffer.resize(request_query_header_size + key.size());
 
         auto *_header = reinterpret_cast<request_query_header *>(_buffer.data()); // NOSONAR
         _header->request_type_ = request_types::query;
+        _header->key_size_ = static_cast<uint8_t>(key.size());
 
-        std::memcpy(_buffer.data() + request_query_header_size, key_id.data(), key_id.size());
+        std::memcpy(_buffer.data() + request_query_header_size, key.data(), key.size());
 
         return _buffer;
     }
@@ -584,20 +585,20 @@ namespace throttr {
     /**
      * Request purge builder
      *
-     * @param key_id
+     * @param key
      * @return std::vector<std::byte>
      */
     inline std::vector<std::byte> request_purge_builder(
-        const std::string_view key_id = ""
+        const std::string_view key = ""
     ) {
         std::vector<std::byte> _buffer;
-        _buffer.resize(request_purge_header_size + key_id.size());
+        _buffer.resize(request_purge_header_size + key.size());
 
         auto *_header = reinterpret_cast<request_purge_header *>(_buffer.data()); // NOSONAR
         _header->request_type_ = request_types::purge;
-        _header->key_id_size_ = static_cast<uint8_t>(key_id.size());
+        _header->key_size_ = static_cast<uint8_t>(key.size());
 
-        std::memcpy(_buffer.data() + request_purge_header_size, key_id.data(), key_id.size());
+        std::memcpy(_buffer.data() + request_purge_header_size, key.data(), key.size());
 
         return _buffer;
     }
@@ -608,26 +609,26 @@ namespace throttr {
      * @param attribute
      * @param change
      * @param value
-     * @param key_id
+     * @param key
      * @return std::vector<std::byte>
      */
     inline std::vector<std::byte> request_update_builder(
         const attribute_types attribute = attribute_types::quota,
         const change_types change = change_types::patch,
         const uint16_t value = 0,
-        const std::string_view key_id = ""
+        const std::string_view key = ""
     ) {
         std::vector<std::byte> _buffer;
-        _buffer.resize(request_update_header_size + key_id.size());
+        _buffer.resize(request_update_header_size + key.size());
 
         auto *_header = reinterpret_cast<request_update_header *>(_buffer.data()); // NOSONAR
         _header->request_type_ = request_types::update;
         _header->attribute_ = attribute;
         _header->change_ = change;
         _header->value_ = value;
-        _header->key_id_size_ = static_cast<uint8_t>(key_id.size());
+        _header->key_size_ = static_cast<uint8_t>(key.size());
 
-        std::memcpy(_buffer.data() + request_update_header_size, key_id.data(), key_id.size());
+        std::memcpy(_buffer.data() + request_update_header_size, key.data(), key.size());
 
         return _buffer;
     }

--- a/tests/protocol.cc
+++ b/tests/protocol.cc
@@ -22,16 +22,13 @@ using namespace throttr;
 using namespace std::chrono;
 
 TEST(RequestInsertTest, ParseAndSerialize) {
-    auto _buffer = request_insert_builder(
-        0, 5000, ttl_types::milliseconds, 60000, "consumer123", "/api/resource"
-    );
+    auto _buffer = request_insert_builder(5000, ttl_types::milliseconds, 60000, "127.0.0.1:8000/api/resource");
 
     const auto _request = request_insert::from_buffer(_buffer);
     EXPECT_EQ(_request.header_->quota_, 5000);
     EXPECT_EQ(_request.header_->ttl_type_, ttl_types::milliseconds);
     EXPECT_EQ(_request.header_->ttl_, 60000);
-    EXPECT_EQ(_request.consumer_id_, "consumer123");
-    EXPECT_EQ(_request.resource_id_, "/api/resource");
+    EXPECT_EQ(_request.key_, "127.0.0.1:8000/api/resource");
 
     auto _reconstructed = _request.to_buffer();
     ASSERT_EQ(_reconstructed.size(), _buffer.size());
@@ -39,11 +36,10 @@ TEST(RequestInsertTest, ParseAndSerialize) {
 }
 
 TEST(RequestQueryTest, ParseAndSerialize) {
-    auto _buffer = request_query_builder(0, "consumerABC", "/resourceXYZ");
+    auto _buffer = request_query_builder("0fa80d9d-d371-4f16-9c50-1bfa13f199b5");
 
     const auto _request = request_query::from_buffer(_buffer);
-    EXPECT_EQ(_request.consumer_id_, "consumerABC");
-    EXPECT_EQ(_request.resource_id_, "/resourceXYZ");
+    EXPECT_EQ(_request.key_, "0fa80d9d-d371-4f16-9c50-1bfa13f199b5");
 
     auto _reconstructed = _request.to_buffer();
     ASSERT_EQ(_reconstructed.size(), _buffer.size());
@@ -56,14 +52,12 @@ TEST(RequestInsertTest, RejectsTooSmallBuffer) {
 }
 
 TEST(RequestQueryTest, RejectsTooSmallBuffer) {
-    std::vector _buffer(2, static_cast<std::byte>(0));
+    std::vector _buffer(1, static_cast<std::byte>(0));
     ASSERT_THROW(request_query::from_buffer(_buffer), request_error);
 }
 
 TEST(RequestInsertBenchmark, DecodePerformance) {
-    auto _buffer = request_insert_builder(
-        0, 5000, ttl_types::milliseconds, 60000, "consumer123", "/api/benchmark"
-    );
+    auto _buffer = request_insert_builder(5000, ttl_types::milliseconds, 60000, "benchmark");
 
     constexpr size_t _iterations = 1'000'000;
     const auto _start = high_resolution_clock::now();
@@ -81,16 +75,14 @@ TEST(RequestInsertBenchmark, DecodePerformance) {
 }
 
 TEST(RequestQueryBenchmark, DecodePerformance) {
-    auto _buffer = request_query_builder(
-        0, "consumerABC", "/api/query"
-    );
+    auto _buffer = request_query_builder("benchmark");
 
     constexpr size_t _iterations = 1'000'000;
     const auto _start = high_resolution_clock::now();
 
     for (size_t _i = 0; _i < _iterations; ++_i) {
         auto _view = request_query::from_buffer(_buffer);
-        EXPECT_EQ(_view.consumer_id_, "consumerABC");
+        EXPECT_EQ(_view.key_, "benchmark");
     }
 
     const auto _end = high_resolution_clock::now();
@@ -101,41 +93,36 @@ TEST(RequestQueryBenchmark, DecodePerformance) {
 }
 
 TEST(RequestInsertTest, RejectsInvalidPayloadSize) {
-    std::vector<std::byte> _buffer(request_insert_header_size + 5);
+    std::vector<std::byte> _buffer(request_insert_header_size + 3);
 
     auto *_header = reinterpret_cast<request_insert_header *>(_buffer.data()); // NOSONAR
     _header->request_type_ = request_types::insert;
     _header->quota_ = 10;
     _header->ttl_type_ = ttl_types::milliseconds;
     _header->ttl_ = 10000;
-    _header->consumer_id_size_ = 5;
-    _header->resource_id_size_ = 5;
+    _header->key_size_ = 5;
 
     ASSERT_THROW(request_insert::from_buffer(_buffer), request_error);
 }
 
 TEST(RequestQueryTest, RejectsInvalidPayloadSize) {
-    std::vector<std::byte> _buffer(request_query_header_size + 5);
+    std::vector<std::byte> _buffer(request_query_header_size + 3);
 
     auto *_header = reinterpret_cast<request_query_header *>(_buffer.data()); // NOSONAR
     _header->request_type_ = request_types::query;
-    _header->consumer_id_size_ = 5;
-    _header->resource_id_size_ = 5;
+    _header->key_size_ = 5;
 
     ASSERT_THROW(request_query::from_buffer(_buffer), request_error);
 }
 
 TEST(RequestUpdateTest, ParseAndSerialize) {
-    auto _buffer = request_update_builder(
-        0, attribute_types::quota, change_types::patch, 5000, "consumerX", "/resourceX"
-    );
+    auto _buffer = request_update_builder(attribute_types::quota, change_types::patch, 5000, "x");
 
     const auto _request = request_update::from_buffer(_buffer);
     EXPECT_EQ(_request.header_->attribute_, attribute_types::quota);
     EXPECT_EQ(_request.header_->change_, change_types::patch);
     EXPECT_EQ(_request.header_->value_, 5000);
-    EXPECT_EQ(_request.consumer_id_, "consumerX");
-    EXPECT_EQ(_request.resource_id_, "/resourceX");
+    EXPECT_EQ(_request.key_, "x");
 
     auto _reconstructed = _request.to_buffer();
     ASSERT_EQ(_reconstructed.size(), _buffer.size());
@@ -148,136 +135,89 @@ TEST(RequestUpdateTest, RejectsTooSmallBuffer) {
 }
 
 TEST(RequestUpdateTest, RejectsInvalidPayloadSize) {
-    std::vector<std::byte> _buffer(request_update_header_size + 5);
+    std::vector<std::byte> _buffer(request_update_header_size + 3);
 
     auto *_header = reinterpret_cast<request_update_header *>(_buffer.data()); // NOSONAR
     _header->request_type_ = request_types::update;
     _header->attribute_ = attribute_types::quota;
     _header->change_ = change_types::patch;
     _header->value_ = 5000;
-    _header->consumer_id_size_ = 5;
-    _header->resource_id_size_ = 5;
+    _header->key_size_ = 5;
 
     ASSERT_THROW(request_update::from_buffer(_buffer), request_error);
 }
 
 TEST(RequestPurgeTest, ParseAndSerialize) {
-    auto _buffer = request_purge_builder(0, "consumerPURGE", "/resourcePURGE");
+    auto _buffer = request_purge_builder("v5");
 
     const auto _request = request_purge::from_buffer(_buffer);
-    EXPECT_EQ(_request.consumer_id_, "consumerPURGE");
-    EXPECT_EQ(_request.resource_id_, "/resourcePURGE");
+    EXPECT_EQ(_request.key_, "v5");
 
     auto _reconstructed = _request.to_buffer();
     ASSERT_EQ(_reconstructed.size(), _buffer.size());
     ASSERT_TRUE(std::equal(_reconstructed.begin(), _reconstructed.end(), _buffer.begin()));
 }
 
-TEST(Requests, ContainsIdentification) {
-    auto _insert_buffer = request_insert_builder(1, 0, ttl_types::milliseconds, 100, "insert", "/insert");
-    const auto _insert_request = request_insert::from_buffer(_insert_buffer);
-    EXPECT_EQ(_insert_request.header_->request_id_, 1);
-
-    auto _query_buffer = request_query_builder(2, "query", "/query");
-    const auto _query_request = request_query::from_buffer(_query_buffer);
-    EXPECT_EQ(_query_request.header_->request_id_, 2);
-
-    auto _update_buffer = request_update_builder(3, attribute_types::quota, change_types::increase, 5, "update", "/update");
-    const auto _update_request = request_update::from_buffer(_update_buffer);
-    EXPECT_EQ(_update_request.header_->request_id_, 3);
-
-    auto _purge_buffer = request_purge_builder(4, "purge", "/purge");
-    const auto _purge_request = request_purge::from_buffer(_purge_buffer);
-    EXPECT_EQ(_purge_request.header_->request_id_, 4);
-}
-
-
 TEST(RequestPurgeTest, RejectsTooSmallBuffer) {
-    std::vector _buffer(2, static_cast<std::byte>(0));
+    std::vector _buffer(1, static_cast<std::byte>(0));
     ASSERT_THROW(request_purge::from_buffer(_buffer), request_error);
 }
 
 TEST(RequestPurgeTest, RejectsInvalidPayloadSize) {
-    std::vector<std::byte> _buffer(request_purge_header_size + 5);
+    std::vector<std::byte> _buffer(request_purge_header_size + 3);
 
     auto *_header = reinterpret_cast<request_purge_header *>(_buffer.data()); // NOSONAR
     _header->request_type_ = request_types::purge;
-    _header->consumer_id_size_ = 5;
-    _header->resource_id_size_ = 5;
+    _header->key_size_ = 5;
 
     ASSERT_THROW(request_purge::from_buffer(_buffer), request_error);
 }
 
 
 TEST(RequestKeyTest, EqualsIdenticalKeys) {
-    const request_key _a{"consumer1","/resource1"};
-
-    const request_key _b{"consumer1","/resource1"};
-
+    const request_key _a{"equals"};
+    const request_key _b{"equals"};
+    EXPECT_EQ(_a, _b);
     EXPECT_TRUE(_a == _b);
 }
 
-TEST(RequestKeyTest, NotEqualsDifferentConsumerID) {
-    const request_key _a{"consumer1","/resource1"};
-
-    const request_key _b{"consumer2","/resource1"};
-
-    EXPECT_FALSE(_a == _b);
-}
-
-TEST(RequestKeyTest, NotEqualsDifferentResourceID) {
-    const request_key _a{"consumer1","/resource1"};
-
-    const request_key _b{"consumer1","/resource2"};
-
-    EXPECT_FALSE(_a == _b);
-}
-
-TEST(RequestKeyTest, NotEqualsDifferentBothFields) {
-    const request_key _a{"consumer1", "/resource1"};
-
-    const request_key _b{"consumer2", "/resource2"};
-
+TEST(RequestKeyTest, NotEqualsDifferentKey) {
+    const request_key _a{"a"};
+    const request_key _b{"b"};
     EXPECT_FALSE(_a == _b);
 }
 
 TEST(RequestKeyTest, ComparesByContentNotPointer) {
     const std::string base1 = "consumerA";
-    const std::string base2 = "consumerA"; // Distinto objeto, mismo contenido
+    const std::string base2 = "consumerA";
     const std::string base3 = "consumerB";
 
-    const std::string path1 = "/resourceX";
-    const std::string path2 = "/resourceX"; // Mismo contenido
-    const std::string path3 = "/resourceY";
-
-    request_key key1{std::string_view(base1), std::string_view(path1)};
-    request_key key2{std::string_view(base2), std::string_view(path2)};
-    request_key key3{std::string_view(base3), std::string_view(path1)};
-    request_key key4{std::string_view(base1), std::string_view(path3)};
+    const request_key key1{std::string_view(base1)};
+    const request_key key2{std::string_view(base2)};
+    const request_key key3{std::string_view(base3)};
 
     EXPECT_TRUE(key1 == key2);
     EXPECT_FALSE(key1 == key3);
-    EXPECT_FALSE(key1 == key4);
 }
 
 TEST(RequestKeyHasherTest, ProducesSameHashForEquivalentKeys) {
     const std::string a = "consumerZ";
     const std::string b = "/resourceZ";
 
-    request_key key1{std::string_view(a), std::string_view(b)};
-    request_key key2{std::string_view("consumerZ"), std::string_view("/resourceZ")};
+    const request_key key1{"a"};
+    const request_key key2{"a"};
 
-    request_key_hasher hasher;
+    constexpr request_key_hasher hasher;
 
     EXPECT_EQ(hasher(key1), hasher(key2));
 }
 
 TEST(RequestKeyHasherTest, ProducesDifferentHashForDifferentKeys) {
-    request_key_hasher hasher;
+    constexpr request_key_hasher hasher;
 
-    request_key k1{"A", "X"};
-    request_key k2{"B", "X"};
-    request_key k3{"A", "Y"};
+    const request_key k1{"a"};
+    const request_key k2{"b"};
+    const request_key k3{"c"};
 
     EXPECT_NE(hasher(k1), hasher(k2));
     EXPECT_NE(hasher(k1), hasher(k3));

--- a/tests/protocol.cc
+++ b/tests/protocol.cc
@@ -240,3 +240,22 @@ TEST(RequestKeyTest, NotEqualsDifferentBothFields) {
 
     EXPECT_FALSE(_a == _b);
 }
+
+TEST(RequestKeyTest, ComparesByContentNotPointer) {
+    const std::string base1 = "consumerA";
+    const std::string base2 = "consumerA"; // Distinto objeto, mismo contenido
+    const std::string base3 = "consumerB";
+
+    const std::string path1 = "/resourceX";
+    const std::string path2 = "/resourceX"; // Mismo contenido
+    const std::string path3 = "/resourceY";
+
+    request_key key1{std::string_view(base1), std::string_view(path1)};
+    request_key key2{std::string_view(base2), std::string_view(path2)};
+    request_key key3{std::string_view(base3), std::string_view(path1)};
+    request_key key4{std::string_view(base1), std::string_view(path3)};
+
+    EXPECT_TRUE(key1 == key2);
+    EXPECT_FALSE(key1 == key3);
+    EXPECT_FALSE(key1 == key4);
+}

--- a/tests/protocol.cc
+++ b/tests/protocol.cc
@@ -259,3 +259,26 @@ TEST(RequestKeyTest, ComparesByContentNotPointer) {
     EXPECT_FALSE(key1 == key3);
     EXPECT_FALSE(key1 == key4);
 }
+
+TEST(RequestKeyHasherTest, ProducesSameHashForEquivalentKeys) {
+    const std::string a = "consumerZ";
+    const std::string b = "/resourceZ";
+
+    request_key key1{std::string_view(a), std::string_view(b)};
+    request_key key2{std::string_view("consumerZ"), std::string_view("/resourceZ")};
+
+    request_key_hasher hasher;
+
+    EXPECT_EQ(hasher(key1), hasher(key2));
+}
+
+TEST(RequestKeyHasherTest, ProducesDifferentHashForDifferentKeys) {
+    request_key_hasher hasher;
+
+    request_key k1{"A", "X"};
+    request_key k2{"B", "X"};
+    request_key k3{"A", "Y"};
+
+    EXPECT_NE(hasher(k1), hasher(k2));
+    EXPECT_NE(hasher(k1), hasher(k3));
+}


### PR DESCRIPTION
This PR creates a big change.

Reasons:

- Quotas and TTL's, both, combined, can use different setups to solve the same problem.

> You don't need to use 1'000'000'000'000 nanoseconds to describe a second.

> You don't need to use 1'000'000 requests per second if you could say 1'000 per miliseconds.

This reduces the amount of bytes on quota and TTL on 1/8 of the original size. 

Previously both has been using `uint64_t` (8 bytes per value), right now we gonna use `uint16_t` (2 bytes per value).

Right now we don't use `consumer_id` + `resource_id`. Right now is `key_id`. Less overhead.

You should have to define how to deal with it. Like using `127.0.0.1:7000|/api/user` or binary representations of `UUIDv4` or whatever. At least you have `255` bytes to play.